### PR TITLE
Run concurrent jobs for Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,23 @@ name: test
 on: [push]
 
 jobs:
-  test:
-    name: run test
+  setup:
+    name: setup
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target          
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+  fmt:
+    name: run fmt
+    runs-on: ubuntu-latest
+    needs: setup
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -18,15 +32,47 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: rustfmt, clippy
+          components: rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+  clippy:
+    name: run clippy
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target          
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
+
+  test:
+    name: run test
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target          
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
## :notebook: Description
CI runs static checks and tests with Github Actions, but sequentially.  
This change separates the job into setup(cache), fmt, clippy and test.

## :wrench: Features or Solutions
* Separates Github Actions test job.
  * makes to run concurrently fmt, clippy and tests. 

## :warning: Breaking changes
* Nothing